### PR TITLE
rename column 'order_status_id' in orders table to 'order_status'

### DIFF
--- a/src/main/resources/sql/navigation_schema.sql
+++ b/src/main/resources/sql/navigation_schema.sql
@@ -135,7 +135,7 @@ ENGINE = InnoDB;
 CREATE TABLE IF NOT EXISTS `navigation`.`orders` (
   `order_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `order_number` VARCHAR(75) NULL,
-  `order_status_id` VARCHAR(45) NULL,
+  `order_status` VARCHAR(45) NULL,
   `order_date` DATETIME NULL,
   `delivery_date` DATETIME NULL,
   `storage_id` INT UNSIGNED NULL COMMENT 'The origin location of the order.',


### PR DESCRIPTION
There is a minor mistake with the name of a column on our database schema which was an oversight on my part when I was made the column. The column in `src/main/resources/sql/navigation_schema.sql` has been renamed. The corresponding field in `com.solvd.navigator.bin.Order` needs to be changed to reflect this. Please see the screenshot:


![screen1](https://github.com/dctii/navigator/assets/61774862/9c356060-b0de-41e5-aca1-0e67ef7ea4c6)
