### PR TITLE
add instructions for running the GraphTester entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ mvn clean install
 mvn exec:java -P base-data-loader
 ```
 
+### Run `GraphTester.class`
+
+```shell
+# Run `clean install`
+mvn clean install
+
+# Run the the primary profile to run the services
+mvn exec:java -P graph-tester
+
+```
+
 ### Run `Main.class`
 
 ```shell


### PR DESCRIPTION
GraphTester entry point is a place to test out the logic of the math layer. It will be removed after the Main entry point is populated.