### PR TITLE
Dana dev - update tests in GraphTester, fixed breaking bug for findFastestRoute method

### DIFF
--- a/src/main/java/com/solvd/navigator/BaseDataLoader.java
+++ b/src/main/java/com/solvd/navigator/BaseDataLoader.java
@@ -4,7 +4,6 @@ package com.solvd.navigator;
 import com.solvd.navigator.bin.Location;
 import com.solvd.navigator.math.util.JsonDataStore;
 import com.solvd.navigator.util.AnsiCodes;
-import com.solvd.navigator.util.FilepathConstants;
 import com.solvd.navigator.util.LoadUtils;
 import com.solvd.navigator.util.StringConstants;
 import org.apache.logging.log4j.LogManager;
@@ -31,129 +30,28 @@ public class BaseDataLoader {
         );
 
         while (true) {
-            LOGGER.info(StringConstants.NEWLINE);
 
-            LOGGER.info("{}{}=== Airport Base Data Loading Tools: ==={}",
-                    AnsiCodes.BOLD, AnsiCodes.YELLOW, AnsiCodes.RESET_ALL);
+            LOGGER.info(
+                    "{}{}{}=== Navigator Base Data Loading Tools: ==={}",
+                    StringConstants.NEWLINE, AnsiCodes.BOLD, AnsiCodes.YELLOW, AnsiCodes.RESET_ALL
+            );
             LOGGER.info("[0] Exit");
-            LOGGER.info("{}{}[1] Execute all 'Load' options{}", AnsiCodes.BLUE, AnsiCodes.BOLD, AnsiCodes.RESET_ALL);
-            LOGGER.info("[2] Load Locations Data");
-            LOGGER.info("[3] Load Storages Data");
-            LOGGER.info("[4] Load Persons Data");
-            LOGGER.info("[5] Load Employees Data");
-            LOGGER.info("[6] Load Vehicles Data");
-            LOGGER.info("[7] Load Drivers Data");
-            LOGGER.info("[8] Load OrderRecipients Data");
-            LOGGER.info("[9] Load Orders Data");
+            LOGGER.info(
+                    "{}{}[1] Load all data: locations, persons, employees, vehicles, drivers, order recipients, and orders{}{}",
+                    AnsiCodes.BLUE, AnsiCodes.BOLD, AnsiCodes.RESET_ALL, StringConstants.NEWLINE
+            );
 
-            LOGGER.info(StringConstants.NEWLINE + "Enter your choice: ");
+            LOGGER.info("{}Enter your choice: {}", StringConstants.NEWLINE, StringConstants.NEWLINE);
 
             int choice = scanner.nextInt();
-            LOGGER.info(StringConstants.NEWLINE);
 
             scanner.nextLine();
 
             switch (choice) {
                 case 1:
-                    // Loading should be done in the order that each LoadUtils.* method is in below in 'case 1':
-                    LoadUtils.loadLocationsData(FilepathConstants.LOCATIONS_JSON);
-                    LOGGER.info(StringConstants.NEWLINE);
-
-                    currentAvailableLocations =
-                            LoadUtils.loadStoragesData(FilepathConstants.STORAGES_JSON, currentAvailableLocations);
-
-                    LOGGER.info(
-                            "{}Current Amount of Available Locations: {}{}",
-                            AnsiCodes.YELLOW,
-                            currentAvailableLocations.size(),
-                            AnsiCodes.RESET_ALL
-                    );
-
-                    LOGGER.info(StringConstants.NEWLINE);
-
-                    // generate first and last name with javafaker
-                    LoadUtils.loadPersonsData();
-                    LOGGER.info(StringConstants.NEWLINE);
-
-                    // Employees must be personId=1 and personId=2
-                    LoadUtils.loadEmployeesData(FilepathConstants.EMPLOYEES_JSON);
-                    LOGGER.info(StringConstants.NEWLINE);
-
-                    LoadUtils.loadVehiclesData(FilepathConstants.VEHICLES_JSON);
-                    LOGGER.info(StringConstants.NEWLINE);
-
-                    // driver are employeeId=1 and employeeId=2; and vehicleId=1 and vehicleId=2
-                    LoadUtils.loadDriversData(FilepathConstants.DRIVERS_JSON);
-                    LOGGER.info(StringConstants.NEWLINE);
-
-                    // generate, map on to persons
-                    // order recipients must be all personId > 2
-
-                    currentAvailableLocations =
-                            LoadUtils.loadOrderRecipientsData(currentAvailableLocations);
-
-                    LOGGER.info(
-                            "{}Current Amount of Available Locations: {}{}",
-                            AnsiCodes.YELLOW,
-                            currentAvailableLocations.size(),
-                            AnsiCodes.RESET_ALL
-                    );
-
-                    LOGGER.info(StringConstants.NEWLINE);
-
-                    // generate 960 (number or orders per storage) * 4 (number of storages), map on to generated order recipients
-                    LoadUtils.loadOrdersData();
-                    break;
-                case 2:
-                    LOGGER.info("Uploading Locations...");
-                    LoadUtils.loadLocationsData(FilepathConstants.LOCATIONS_JSON);
-                    break;
-                case 3:
-                    LOGGER.info("Uploading Storages...");
-                    currentAvailableLocations =
-                            LoadUtils.loadStoragesData(
-                                    FilepathConstants.STORAGES_JSON,
-                                    currentAvailableLocations
-                            );
-
-                    LOGGER.info(
-                            "{}Current Amount of Available Locations: {}{}",
-                            AnsiCodes.YELLOW,
-                            currentAvailableLocations.size(),
-                            AnsiCodes.RESET_ALL
-                    );
-                    break;
-                case 4:
-                    LOGGER.info("Uploading Persons...");
-                    LoadUtils.loadPersonsData();
-                    break;
-                case 5:
-                    LOGGER.info("Uploading Employees...");
-                    LoadUtils.loadEmployeesData(FilepathConstants.EMPLOYEES_JSON);
-                    break;
-                case 6:
-                    LOGGER.info("Uploading Vehicles...");
-                    LoadUtils.loadVehiclesData(FilepathConstants.VEHICLES_JSON);
-                    break;
-                case 7:
-                    LOGGER.info("Uploading Drivers...");
-                    LoadUtils.loadDriversData(FilepathConstants.DRIVERS_JSON);
-                    break;
-                case 8:
-                    LOGGER.info("Uploading Order Recipients...");
-                    currentAvailableLocations =
-                            LoadUtils.loadOrderRecipientsData(currentAvailableLocations);
-
-                    LOGGER.info(
-                            "{}Current Amount of Available Locations: {}{}",
-                            AnsiCodes.YELLOW,
-                            currentAvailableLocations.size(),
-                            AnsiCodes.RESET_ALL
-                    );
-                    break;
-                case 9:
-                    LOGGER.info("Uploading Orders...");
-                    LoadUtils.loadOrdersData();
+                    LoadUtils.loadAllData(currentAvailableLocations);
+                    LOGGER.info("{}All of the data has been successfully loaded, exiting program.{}", AnsiCodes.BLUE, AnsiCodes.RESET_ALL);
+                    System.exit(0);
                     break;
                 case 0:
                     LOGGER.info("Exiting...");

--- a/src/main/java/com/solvd/navigator/exception/InvalidLocationException.java
+++ b/src/main/java/com/solvd/navigator/exception/InvalidLocationException.java
@@ -1,6 +1,7 @@
 package com.solvd.navigator.exception;
-public class InvalidLocationException {
-    public static void main(String[] args) {
-        
+
+public class InvalidLocationException extends RuntimeException {
+    public InvalidLocationException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/com/solvd/navigator/exception/InvalidLocationException.java
+++ b/src/main/java/com/solvd/navigator/exception/InvalidLocationException.java
@@ -1,0 +1,6 @@
+package com.solvd.navigator.exception;
+public class InvalidLocationException {
+    public static void main(String[] args) {
+        
+    }
+}

--- a/src/main/java/com/solvd/navigator/exception/StorageLocationNotFoundException.java
+++ b/src/main/java/com/solvd/navigator/exception/StorageLocationNotFoundException.java
@@ -1,6 +1,7 @@
 package com.solvd.navigator.exception;
-public class StorageLocationNotFoundException {
-    public static void main(String[] args) {
-        
+
+public class StorageLocationNotFoundException extends RuntimeException {
+    public StorageLocationNotFoundException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/com/solvd/navigator/exception/StorageLocationNotFoundException.java
+++ b/src/main/java/com/solvd/navigator/exception/StorageLocationNotFoundException.java
@@ -1,0 +1,6 @@
+package com.solvd.navigator.exception;
+public class StorageLocationNotFoundException {
+    public static void main(String[] args) {
+        
+    }
+}

--- a/src/main/java/com/solvd/navigator/math/util/OrderConstants.java
+++ b/src/main/java/com/solvd/navigator/math/util/OrderConstants.java
@@ -2,6 +2,7 @@ package com.solvd.navigator.math.util;
 
 import com.solvd.navigator.util.ClassConstants;
 import com.solvd.navigator.util.ExceptionUtils;
+import com.solvd.navigator.util.NumberUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,8 +27,11 @@ public final class OrderConstants {
     public static final int TOTAL_NUMBER_OF_ORDER_RECIPIENTS =
             TOTAL_NUMBER_OF_PERSONS - TOTAL_NUMBER_OF_DRIVERS;
 
-    public static final int TOTAL_NUMBER_OF_ORDERS_PER_WAREHOUSE = 960;
-    public static final int TOTAL_NUMBER_OF_ORDERS = 960 * ALL_STORAGE_WAREHOUSE_IDS.size();
+    public static final int TOTAL_NUMBER_OF_ORDERS_PER_WAREHOUSE = 1000;
+    public static final int TOTAL_NUMBER_OF_ORDERS = TOTAL_NUMBER_OF_ORDERS_PER_WAREHOUSE * ALL_STORAGE_WAREHOUSE_IDS.size();
+
+    public static final double MAX_WORK_HOURS = 8.0;
+    public static final double MAX_WORK_HOURS_IN_MINUTES = NumberUtils.roundToScale(MAX_WORK_HOURS * 60, 2);
 
 
     private OrderConstants() {

--- a/src/main/java/com/solvd/navigator/math/util/RouteUtils.java
+++ b/src/main/java/com/solvd/navigator/math/util/RouteUtils.java
@@ -2,6 +2,7 @@ package com.solvd.navigator.math.util;
 
 import com.solvd.navigator.bin.Location;
 import com.solvd.navigator.bin.Storage;
+import com.solvd.navigator.exception.StorageLocationNotFoundException;
 import com.solvd.navigator.math.graph.ShortestPathsMatrix;
 import com.solvd.navigator.math.graph.WeightedGraph;
 import com.solvd.navigator.util.BooleanUtils;
@@ -35,6 +36,7 @@ public class RouteUtils {
         Set<Integer> visitedLocationIds = new HashSet<>();
 
         int currentLocationId = startingLocation.getLocationId();
+
         fastRoute.add(startingLocation);
         visitedLocationIds.add(currentLocationId);
 
@@ -54,19 +56,31 @@ public class RouteUtils {
                 }
             }
 
+            /* 2024-01JAN-25
+                Bug resolved by adding the `break`. Was not able to exit loop
+                whenever a duplicate location (order destination) was in the
+                same locationsForRoute list.
+            */
             if (closestLocation != null) {
                 visitedLocationIds.add(closestLocation.getLocationId());
                 fastRoute.add(closestLocation);
                 currentLocationId = closestLocation.getLocationId();
+            } else {
+                // if null, there was/were duplicate locations for the order, so break
+                break;
             }
         }
 
-        // Find the nearest storage location after completing all deliveries
+        // find the nearest storage location
         Location lastDeliveryLocation = fastRoute.get(fastRoute.size() - 1);
         Location nearestStorageLocation = findNearestStorageLocation(lastDeliveryLocation, storages, matrix);
 
         if (nearestStorageLocation != null) {
             fastRoute.add(nearestStorageLocation);
+        } else {
+            final String CANNOT_FIND_STORAGE_EXCEPTION_MSG = "Unable to find nearby storage location.";
+            LOGGER.error(CANNOT_FIND_STORAGE_EXCEPTION_MSG);
+            throw new StorageLocationNotFoundException(CANNOT_FIND_STORAGE_EXCEPTION_MSG);
         }
 
         return fastRoute;

--- a/src/main/java/com/solvd/navigator/util/CollectionUtils.java
+++ b/src/main/java/com/solvd/navigator/util/CollectionUtils.java
@@ -3,16 +3,28 @@ package com.solvd.navigator.util;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
+import java.util.Random;
 import java.util.Set;
 
 public class CollectionUtils {
     private static final Logger LOGGER = LogManager.getLogger(ClassConstants.COLLECTION_UTILS);
+    private static final Random random = new Random();
 
     public static <T> Set<T> setToNullIfEmpty(Set<T> collection) {
         if (BooleanUtils.isEmptyOrNullCollection(collection)) {
             collection = null;
         }
         return collection;
+    }
+
+    public static <T> T getRandomItemFromList(List<T> list) {
+        if (BooleanUtils.isEmptyOrNullCollection(list)) {
+            throw new IllegalStateException("Collection cannot be empty ");
+        }
+
+        int randomIndex = random.nextInt(list.size());
+        return list.get(randomIndex);
     }
 
     private CollectionUtils() {

--- a/src/main/java/com/solvd/navigator/util/JacksonUtils.java
+++ b/src/main/java/com/solvd/navigator/util/JacksonUtils.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -84,10 +83,9 @@ public class JacksonUtils {
     }
 
     public static Storage getRandomStorage(List<Storage> storages) {
-        Random random = new Random();
-        int randomIndex = random.nextInt(storages.size()); // Generate a random index
-        return storages.get(randomIndex); // Get the storage at the random index
+        return CollectionUtils.getRandomItemFromList(storages);
     }
+
 
 
     public static Storage getStorageByLocationId(int locationId, List<Storage> storages) {

--- a/src/main/java/com/solvd/navigator/util/LoadUtils.java
+++ b/src/main/java/com/solvd/navigator/util/LoadUtils.java
@@ -27,12 +27,67 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.IntStream;
 
 public class LoadUtils {
     private static final Logger LOGGER = LogManager.getLogger(ClassConstants.LOAD_UTILS);
+
+    public static final String LOCATIONS_JSON_KEY = "locations";
+    public static final String STORAGES_JSON_KEY = "storages";
+    public static final String EMPLOYEES_JSON_KEY = "employees";
+    public static final String VEHICLES_JSON_KEY = "vehicles";
+    public static final String DRIVERS_JSON_KEY = "drivers";
+
+    public static void loadAllData(List<Location> currentAvailableLocations) {
+        final Map<String, String> jsonFilepathMap = Map.of(
+                LOCATIONS_JSON_KEY, FilepathConstants.LOCATIONS_JSON,
+                STORAGES_JSON_KEY, FilepathConstants.STORAGES_JSON,
+                EMPLOYEES_JSON_KEY, FilepathConstants.EMPLOYEES_JSON,
+                VEHICLES_JSON_KEY, FilepathConstants.VEHICLES_JSON,
+                DRIVERS_JSON_KEY, FilepathConstants.DRIVERS_JSON
+        );
+
+        loadAllData(jsonFilepathMap, currentAvailableLocations);
+
+    }
+
+    public static void loadAllData(Map<String, String> jsonFilepathMap, List<Location> currentAvailableLocations) {
+        loadLocationsData(jsonFilepathMap.get(LOCATIONS_JSON_KEY));
+
+        currentAvailableLocations =
+                loadStoragesData(jsonFilepathMap.get(STORAGES_JSON_KEY), currentAvailableLocations);
+
+        LOGGER.info(
+                "{}Current Amount of Available Locations: {}{}",
+                AnsiCodes.YELLOW,
+                currentAvailableLocations.size(),
+                AnsiCodes.RESET_ALL
+        );
+
+        loadPersonsData();
+
+        loadEmployeesData(jsonFilepathMap.get(EMPLOYEES_JSON_KEY));
+
+        loadVehiclesData(jsonFilepathMap.get(VEHICLES_JSON_KEY));
+
+        loadDriversData(jsonFilepathMap.get(DRIVERS_JSON_KEY));
+
+        currentAvailableLocations =
+                loadOrderRecipientsData(currentAvailableLocations);
+
+        LOGGER.info(
+                "{}Current Amount of Available Locations: {}{}",
+                AnsiCodes.YELLOW,
+                currentAvailableLocations.size(),
+                AnsiCodes.RESET_ALL
+        );
+
+        LoadUtils.loadOrdersData();
+
+    }
 
     public static void loadLocationsData(String jsonFilepath) {
         final LocationDAO locationDAO = DAOFactory.createDAO(ClassConstants.LOCATION_DAO);


### PR DESCRIPTION
1. Tests in the `GraphTester` entry point are successfully using the `*DAO` interfaces to run its logic instead of interfacing with the smaller set of JSON data.

2. Fixed an important bug for `com.solvd.navigator.math.util.RouteUtils.findFastestRoute()` that was sending the method into an infinite loop. Whenever a duplicate location was in the list of delivery locations passed into the method, it would not account for it, and then the size of the array would never match its comparator. Included this `break` to exit the loop when the duplicate tries to look for a location that has already been accounted for on the fastest routes list.

![image](https://github.com/dctii/navigator/assets/61774862/843f4ae7-f214-427d-ba68-61eabe63ffa8)


Here are additional screenshots of the bug being reproduced when it was breaking:

![produce-1](https://github.com/dctii/navigator/assets/61774862/f50decfa-feb9-4af9-8d79-996548528977)
![produce-2](https://github.com/dctii/navigator/assets/61774862/8a0b434c-c094-4603-aa67-c517824266a6)
![produce-3](https://github.com/dctii/navigator/assets/61774862/aaef152b-9819-430f-88b2-fe9979e2495c)
![produce-4](https://github.com/dctii/navigator/assets/61774862/103e6c5c-7eb6-4170-a3f6-2d790e74d6da)
![produce-5](https://github.com/dctii/navigator/assets/61774862/5d86beef-2925-425f-8938-4ed0e290745e)
