### PR TITLE
add getDistanceBetweenLocations() method to Route- Plan and Calculator

### DIFF
--- a/src/main/java/com/solvd/navigator/math/RouteCalculator.java
+++ b/src/main/java/com/solvd/navigator/math/RouteCalculator.java
@@ -19,4 +19,8 @@ public interface RouteCalculator {
 
     double calculateTotalDistance(List<Location> route);
 
+    double getDistanceBetweenLocations(Location locationFrom, Location locationTo);
+
+    double getDistanceBetweenLocations(int locationFromId, int locationToId);
+
 }

--- a/src/main/java/com/solvd/navigator/math/RouteCalculatorImpl.java
+++ b/src/main/java/com/solvd/navigator/math/RouteCalculatorImpl.java
@@ -146,6 +146,21 @@ public class RouteCalculatorImpl implements RouteCalculator {
         this.locations = locations;
     }
 
+    public double getDistanceBetweenLocations(Location locationFrom, Location locationTo) {
+        return getDistanceBetweenLocations(
+                locationFrom.getLocationId(),
+                locationTo.getLocationId()
+        );
+    }
+
+    public double getDistanceBetweenLocations(int locationFromId, int locationToId) {
+        return RouteUtils.getDistanceBetweenLocations(
+                this.shortestPathsMatrix,
+                locationFromId,
+                locationToId
+        );
+    }
+
     @Override
     public String toString() {
         Class<?> currClass = ClassConstants.ROUTE_CALCULATOR_IMPL;

--- a/src/main/java/com/solvd/navigator/math/RoutePlan.java
+++ b/src/main/java/com/solvd/navigator/math/RoutePlan.java
@@ -105,6 +105,22 @@ public class RoutePlan {
         RouteUtils.printRoute(route);
     }
 
+    public double getDistanceBetweenLocations(
+            RouteCalculator routeCalculator,
+            Location locationFrom,
+            Location locationTo
+    ) {
+        return routeCalculator.getDistanceBetweenLocations(locationFrom, locationTo);
+    }
+
+    public double getDistanceBetweenLocations(
+            RouteCalculator routeCalculator,
+            int locationFromId,
+            int locationToId
+    ) {
+        return routeCalculator.getDistanceBetweenLocations(locationFromId, locationToId);
+    }
+
     // Getter for id
     public UUID getId() {
         return id;

--- a/src/main/java/com/solvd/navigator/math/util/RouteUtils.java
+++ b/src/main/java/com/solvd/navigator/math/util/RouteUtils.java
@@ -147,6 +147,36 @@ public class RouteUtils {
                 .build();
     }
 
+    public static double getDistanceBetweenLocations(
+            ShortestPathsMatrix matrix,
+            Location locationFrom,
+            Location locationTo
+    ) {
+        return getDistanceBetweenLocations(
+                matrix,
+                locationFrom.getLocationId(),
+                locationTo.getLocationId()
+        );
+    }
+
+    public static double getDistanceBetweenLocations(
+            ShortestPathsMatrix matrix,
+            int fromLocationId,
+            int toLocationId
+    ) {
+        Map<Integer, Integer> locationToVertexIndexMap = matrix.getLocationToVertexIndexMap();
+        double[][] shortestDistances = matrix.getShortestDistances();
+
+        int fromLocationIndex = locationToVertexIndexMap.getOrDefault(fromLocationId, -1);
+        int toLocationIndex = locationToVertexIndexMap.getOrDefault(toLocationId, -1);
+
+        if (fromLocationIndex == -1 || toLocationIndex == -1) {
+            throw new IllegalArgumentException("One or both location IDs not found in the shortest path matrix");
+        }
+
+        return shortestDistances[fromLocationIndex][toLocationIndex];
+    }
+
     public static void printRoute(List<Location> route) {
         if (BooleanUtils.isEmptyOrNullCollection(route)) {
             LOGGER.info("No route available.");


### PR DESCRIPTION
`RoutePlan.getDistanceBetweenLocations()` allows you to pass in two `Location` instances or two `int locationId` values and it will return a `double` which is value of the shortest distance in kilometers between the two locations.

Below is an example of how it can be used:

![image](https://github.com/dctii/navigator/assets/61774862/7f8c5f95-863c-4361-96c8-2aaf8461fe63)


```java

// data types for route plan and route calculator
    // RoutePlan routePlan
    // RouteCalculator routeCalculator

double distanceBetweenTwoLocations = NumberUtils.roundToScale(
     routePlan.getDistanceBetweenLocations(
          routeCalculator,
          routePlan.getRoute().get(0),
          routePlan.getRoute().get(1),
      ), 2
);
```