### PR TITLE
add fields and methods and new capture class to get point-to-point paths

### DIFF
--- a/src/main/java/com/solvd/navigator/math/graph/ShortestPathsMatrix.java
+++ b/src/main/java/com/solvd/navigator/math/graph/ShortestPathsMatrix.java
@@ -8,20 +8,24 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ShortestPathsMatrix {
     private static final Logger LOGGER = LogManager.getLogger(ClassConstants.SHORTEST_PATHS_MATRIX);
     private double[][] shortestDistances;
+    private int[][] nextLocations;
     private Map<Integer, Integer> locationIdToIndexMap; // mapping from vertex ID to index in the matrix
 
     private ShortestPathsMatrix(Builder builder) {
         this.shortestDistances = builder.shortestDistances;
+        this.nextLocations = builder.nextLocations;
         this.locationIdToIndexMap = builder.locationIdToIndexMap;
     }
 
     public static class Builder {
         private double[][] shortestDistances;
+        private int[][] nextLocations;
         private Map<Integer, Integer> locationIdToIndexMap;
 
         public Builder() {
@@ -30,6 +34,11 @@ public class ShortestPathsMatrix {
 
         public Builder setShortestDistances(double[][] shortestDistances) {
             this.shortestDistances = shortestDistances;
+            return this;
+        }
+
+        public Builder setNextLocations(int[][] nextLocations) {
+            this.nextLocations = nextLocations;
             return this;
         }
 
@@ -52,6 +61,18 @@ public class ShortestPathsMatrix {
         this.shortestDistances = shortestDistances;
     }
 
+    public int getNextLocationIndex(int fromIndex, int toIndex) {
+        return nextLocations[fromIndex][toIndex];
+    }
+
+    public int[][] getNextLocations() {
+        return nextLocations;
+    }
+
+    public void setNextLocations(int[][] nextLocations) {
+        this.nextLocations = nextLocations;
+    }
+
     public Map<Integer, Integer> getLocationIdToIndexMap() {
         return locationIdToIndexMap;
     }
@@ -60,6 +81,12 @@ public class ShortestPathsMatrix {
         this.locationIdToIndexMap = locationIdToIndexMap;
     }
 
+    public int getLocationIdByMatrixIndex(int matrixIndexNumber) {
+        return MatrixUtils.getLocationIdByMatrixIndex(
+                matrixIndexNumber,
+                this.locationIdToIndexMap
+        );
+    }
 
     public int getMatrixIndexByLocationId(int locationId) {
         return MatrixUtils.getMatrixIndexByLocationId(
@@ -73,6 +100,10 @@ public class ShortestPathsMatrix {
                 vertexId,
                 this.locationIdToIndexMap
         );
+    }
+
+    public List<Integer> getPath(int fromLocationId, int toLocationId) {
+        return MatrixUtils.getPath(this, fromLocationId, toLocationId);
     }
 
     /*

--- a/src/main/java/com/solvd/navigator/math/util/RouteUtils.java
+++ b/src/main/java/com/solvd/navigator/math/util/RouteUtils.java
@@ -31,7 +31,7 @@ public class RouteUtils {
     ) {
         double[][] shortestDistances = matrix.getShortestDistances();
         Map<Integer, Integer> locationToVertexIndexMap = matrix.getLocationIdToIndexMap();
-        
+
         List<Location> fastRoute = new ArrayList<>();
         Set<Integer> visitedLocationIds = new HashSet<>();
 
@@ -128,7 +128,7 @@ public class RouteUtils {
     }
 
     public static ShortestPathsMatrix calculateShortestPaths(WeightedGraph graph, List<Location> locations) {
-        double[][] shortestDistances = MatrixUtils.runFloydWarshall(graph);
+        MatrixUtils.FloydWarshallResult result = MatrixUtils.runFloydWarshall(graph);
 
         Map<Integer, Integer> locationIdToIndexMap =
                 MatrixUtils.mapLocationIdsToMatrixIndexes(locations, graph);
@@ -136,7 +136,8 @@ public class RouteUtils {
 
         // create and return the ShortestPathsMatrix using the Builder
         return new ShortestPathsMatrix.Builder()
-                .setShortestDistances(shortestDistances)
+                .setShortestDistances(result.getShortestDistances())
+                .setNextLocations(result.getNextLocations())
                 .setLocationIdToIndexMap(locationIdToIndexMap)
                 .build();
     }


### PR DESCRIPTION
- Added `FloydWarshallResult` to return more than one piece of data. FloydWarshallResult encapsulates results from the Floyd-Warshall algorithm, `double[][] shortestDistances` and `int[][] nextLocations`. `nextLocations` was not included before as a return result, but always included in the Floyd-Warshall algorithm rendition in the project so far. The `int[][] nextLocations` is used to calculate the point-by-point path from each destination on the "driver's route".
- Added the `getPath(int locationId, int locationId)` method that uses the two location ID numbers to calculate the point by point path. Prior to this, we only had data returned that showed the distance between two locations.